### PR TITLE
iOS project version change from 1 to 2 for 2.0.8

### DIFF
--- a/ios/fitlog.xcodeproj/project.pbxproj
+++ b/ios/fitlog.xcodeproj/project.pbxproj
@@ -5,6 +5,7 @@
 	};
 	objectVersion = 46;
 	objects = {
+
 /* Begin PBXBuildFile section */
 		00E356F31AD99517003FC87E /* fitlogTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 00E356F21AD99517003FC87E /* fitlogTests.m */; };
 		0568FA7B24484C3400E212AC /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 0568FA7A24484C3400E212AC /* LaunchScreen.storyboard */; };
@@ -950,7 +951,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_ENTITLEMENTS = fitlog/fitlog.entitlements;
-				CURRENT_PROJECT_VERSION = 1;
+				CURRENT_PROJECT_VERSION = 2;
 				DEAD_CODE_STRIPPING = NO;
 				DEVELOPMENT_TEAM = 4NS5BD63W7;
 				FRAMEWORK_SEARCH_PATHS = (
@@ -1027,7 +1028,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_ENTITLEMENTS = fitlog/fitlog.entitlements;
-				CURRENT_PROJECT_VERSION = 1;
+				CURRENT_PROJECT_VERSION = 2;
 				DEVELOPMENT_TEAM = 4NS5BD63W7;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",


### PR DESCRIPTION
Had to change the project version to 2 as 1 failed due to some signing issues.